### PR TITLE
Refactor Grant type usage across components to use GrantDetails type

### DIFF
--- a/src/components/GrantDetails.tsx
+++ b/src/components/GrantDetails.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 import GrantNotionHeader from "./grant-notion/GrantNotionHeader";
 import GrantNotionKeyInfo from "./grant-notion/GrantNotionKeyInfo";
 import GrantNotionContent from "./grant-notion/GrantNotionContent";
 import GrantNotionImportantDatesSection from "./grant-notion/GrantNotionImportantDatesSection";
 interface GrantDetailsProps {
-  grant: Grant;
+  grant: GrantDetailsType;
   isBookmarked: boolean;
   onToggleBookmark: () => void;
   isMobile?: boolean;

--- a/src/components/grant-notion/GrantNotionAdditionalInfoSection.tsx
+++ b/src/components/grant-notion/GrantNotionAdditionalInfoSection.tsx
@@ -1,10 +1,10 @@
 
 import React from "react";
 import { ExternalLink } from "lucide-react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 
 interface GrantNotionAdditionalInfoSectionProps {
-  grant: Grant;
+  grant: GrantDetailsType;
 }
 
 const GrantNotionAdditionalInfoSection = ({ grant }: GrantNotionAdditionalInfoSectionProps) => {

--- a/src/components/grant-notion/GrantNotionApplicationSection.tsx
+++ b/src/components/grant-notion/GrantNotionApplicationSection.tsx
@@ -1,9 +1,9 @@
 
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 
 interface GrantNotionApplicationSectionProps {
-  grant: Grant;
+  grant: GrantDetailsType;
 }
 
 const GrantNotionApplicationSection = ({ grant }: GrantNotionApplicationSectionProps) => {

--- a/src/components/grant-notion/GrantNotionContactSection.tsx
+++ b/src/components/grant-notion/GrantNotionContactSection.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 interface GrantNotionContactSectionProps {
-  grant: Grant;
+  grant: GrantDetailsType;
 }
 const GrantNotionContactSection = ({
   grant

--- a/src/components/grant-notion/GrantNotionContent.tsx
+++ b/src/components/grant-notion/GrantNotionContent.tsx
@@ -1,6 +1,6 @@
 
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 import GrantNotionDescriptionSection from "./GrantNotionDescriptionSection";
 import GrantNotionQualificationsSection from "./GrantNotionQualificationsSection";
 import GrantNotionEvaluationSection from "./GrantNotionEvaluationSection";
@@ -10,7 +10,7 @@ import GrantNotionTemplatesSection from "./GrantNotionTemplatesSection";
 import GrantNotionContactSection from "./GrantNotionContactSection";
 
 interface GrantNotionContentProps {
-  grant: Grant;
+  grant: GrantDetailsType;
   isMobile?: boolean;
 }
 

--- a/src/components/grant-notion/GrantNotionDescriptionSection.tsx
+++ b/src/components/grant-notion/GrantNotionDescriptionSection.tsx
@@ -1,18 +1,18 @@
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 
 interface GrantNotionDescriptionSectionProps {
-  grant: Grant;
+  grant: GrantDetailsType;
 }
 
 const GrantNotionDescriptionSection = ({ grant }: GrantNotionDescriptionSectionProps) => {
-  if (!grant.long_description) return null;
+  if (!grant.description) return null;
 
   return (
     <div>
       <h3 className="text-base font-semibold text-gray-900 mb-4">Beskrivning</h3>
       <p className="text-sm text-gray-700 leading-relaxed">
-        {grant.long_description}
+        {grant.description}
       </p>
     </div>
   );

--- a/src/components/grant-notion/GrantNotionEvaluationSection.tsx
+++ b/src/components/grant-notion/GrantNotionEvaluationSection.tsx
@@ -1,9 +1,9 @@
 
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 
 interface GrantNotionEvaluationSectionProps {
-  grant: Grant;
+  grant: GrantDetailsType;
 }
 
 const GrantNotionEvaluationSection = ({ grant }: GrantNotionEvaluationSectionProps) => {

--- a/src/components/grant-notion/GrantNotionFundingRulesSection.tsx
+++ b/src/components/grant-notion/GrantNotionFundingRulesSection.tsx
@@ -1,9 +1,9 @@
 
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 
 interface GrantNotionFundingRulesSectionProps {
-  grant: Grant;
+  grant: GrantDetailsType;
 }
 
 const GrantNotionFundingRulesSection = ({ grant }: GrantNotionFundingRulesSectionProps) => {

--- a/src/components/grant-notion/GrantNotionHeader.tsx
+++ b/src/components/grant-notion/GrantNotionHeader.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Calendar, Bookmark, X, ExternalLink, MoreHorizontal, Share2, Link as LinkIcon, Send } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 import { useSavedGrantsContext } from "@/contexts/SavedGrantsContext";
 import SortingControls, { SortOption } from "@/components/SortingControls";
 import { getOrganizationLogo } from '@/utils/organizationLogos';
@@ -10,7 +10,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 interface GrantNotionHeaderProps {
-  grant: Grant;
+  grant: GrantDetailsType;
   isBookmarked: boolean;
   onToggleBookmark: () => void;
   isMobile?: boolean;
@@ -90,8 +90,8 @@ const GrantNotionHeader = ({
   // Always use the context to determine the actual saved state
   const actuallyBookmarked = isGrantSaved(grant.id);
 
-  // Use subtitle when long_description is available, otherwise use description
-  const displayDescription = grant.long_description ? grant.aboutGrant : grant.description;
+  // Always use subtitle (aboutGrant) for the header description
+  const displayDescription = grant.aboutGrant;
   return <>
       {/* Status label and organization icon inline */}
       <div className="flex items-center gap-2 mb-2 pt-4">

--- a/src/components/grant-notion/GrantNotionImportantDatesSection.tsx
+++ b/src/components/grant-notion/GrantNotionImportantDatesSection.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 
 interface GrantNotionImportantDatesSectionProps {
-  grant: Grant;
+  grant: GrantDetailsType;
 }
 
 interface DateItem {
@@ -37,7 +37,9 @@ const GrantNotionImportantDatesSection = ({ grant }: GrantNotionImportantDatesSe
       project_end_date_max: grant.project_end_date_max,
       information_webinar_dates: grant.information_webinar_dates,
       information_webinar_names: grant.information_webinar_names,
-      information_webinar_links: grant.information_webinar_links
+      information_webinar_links: grant.information_webinar_links,
+      other_important_dates: grant.other_important_dates,
+      other_important_dates_labels: grant.other_important_dates_labels
     });
 
     // Application opening date
@@ -99,6 +101,21 @@ const GrantNotionImportantDatesSection = ({ grant }: GrantNotionImportantDatesSe
           date: displayDate,
           label: webinarName,
           link: webinarLink
+        });
+      });
+    }
+
+    // Other important dates
+    if (grant.other_important_dates && grant.other_important_dates.length > 0) {
+      grant.other_important_dates.forEach((importantDate, index) => {
+        const dateLabel = grant.other_important_dates_labels?.[index] || "Viktigt datum";
+        
+        // Skip null dates or show "Datum saknas"
+        const displayDate = importantDate || "Datum saknas";
+        
+        dates.push({
+          date: displayDate,
+          label: dateLabel
         });
       });
     }

--- a/src/components/grant-notion/GrantNotionKeyInfo.tsx
+++ b/src/components/grant-notion/GrantNotionKeyInfo.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 import { formatCofinancingText } from "@/utils/grantHelpers";
 
 interface GrantNotionKeyInfoProps {
-  grant: Grant;
+  grant: GrantDetailsType;
   isMobile?: boolean;
   section?: 'info' | 'krav';
 }
@@ -19,7 +19,9 @@ const GrantNotionKeyInfo = ({
     cofinancing_required: grant.cofinancing_required,
     cofinancing_level: grant.cofinancing_level,
     fundingRules: grant.fundingRules,
-    region: grant.region
+    region: grant.region,
+    regionType: typeof grant.region,
+    regionExists: grant.region !== undefined && grant.region !== null
   });
 
   // Format helpers

--- a/src/components/grant-notion/GrantNotionQualificationsSection.tsx
+++ b/src/components/grant-notion/GrantNotionQualificationsSection.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 
 interface GrantNotionQualificationsSectionProps {
-  grant: Grant;
+  grant: GrantDetailsType;
 }
 
 const GrantNotionQualificationsSection = ({ grant }: GrantNotionQualificationsSectionProps) => {

--- a/src/components/grant-notion/GrantNotionTemplatesSection.tsx
+++ b/src/components/grant-notion/GrantNotionTemplatesSection.tsx
@@ -1,10 +1,10 @@
 
 import React from "react";
 import { FileText, ExternalLink } from "lucide-react";
-import { Grant } from "@/types/grant";
+import { GrantDetails as GrantDetailsType } from "@/types/grant";
 
 interface GrantNotionTemplatesSectionProps {
-  grant: Grant;
+  grant: GrantDetailsType;
 }
 
 const GrantNotionTemplatesSection = ({ grant }: GrantNotionTemplatesSectionProps) => {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -221,6 +221,8 @@ export type Database = {
           other_sources_names: Json | null
           other_templates_links: Json | null
           other_templates_names: Json | null
+          other_important_dates: Json | null
+          other_important_dates_labels: Json | null
           processed_at: string | null
           processing_status: string | null
           program: string | null
@@ -280,6 +282,8 @@ export type Database = {
           other_sources_names?: Json | null
           other_templates_links?: Json | null
           other_templates_names?: Json | null
+          other_important_dates?: Json | null
+          other_important_dates_labels?: Json | null
           processed_at?: string | null
           processing_status?: string | null
           program?: string | null
@@ -339,6 +343,8 @@ export type Database = {
           other_sources_names?: Json | null
           other_templates_links?: Json | null
           other_templates_names?: Json | null
+          other_important_dates?: Json | null
+          other_important_dates_labels?: Json | null
           processed_at?: string | null
           processing_status?: string | null
           program?: string | null
@@ -654,6 +660,8 @@ export type Database = {
           other_sources_names: Json | null
           other_templates_links: Json | null
           other_templates_names: Json | null
+          other_important_dates: Json | null
+          other_important_dates_labels: Json | null
           processed_at: string | null
           processing_status: string | null
           program: string | null

--- a/src/services/grantsService.ts
+++ b/src/services/grantsService.ts
@@ -188,6 +188,8 @@ const transformGrantListItems = (grantData: any[]): GrantListItem[] => {
         information_webinar_dates: parseJsonArray(grant.information_webinar_dates),
         information_webinar_links: parseJsonArray(grant.information_webinar_links),
         information_webinar_names: parseJsonArray(grant.information_webinar_names),
+        other_important_dates: parseJsonArray(grant.other_important_dates),
+        other_important_dates_labels: parseJsonArray(grant.other_important_dates_labels),
         // Template fields for files and documents
         templates: parseJsonArray(grant.application_templates_names) || [],
         generalInfo: parseJsonArray(grant.other_templates_names) || [],
@@ -219,10 +221,54 @@ const transformGrantListItems = (grantData: any[]): GrantListItem[] => {
 const transformSupabaseGrantToDetails = (grant: any): GrantDetails => {
   const transformedGrant = transformSupabaseGrant(grant);
 
-  // GrantDetails extends Grant, so we can cast it after transformation,
-  // assuming transformSupabaseGrant populates all necessary fields.
-  // We may need to add fields to Grant or handle them here if they are truly details-only.
-  return transformedGrant as GrantDetails;
+  // Create a GrantDetails object that includes the region field
+  const grantDetails: GrantDetails = {
+    ...transformedGrant,
+    region: grant.region || '',
+    // Ensure all GrantDetails specific fields are properly set
+    description: grant.description || grant.subtitle || 'No description available',
+    long_description: grant.long_description || undefined,
+    qualifications: grant.eligibility || 'Not specified',
+    whoCanApply: grant.eligibility || 'Not specified',
+    importantDates: parseJsonArray(grant.information_webinar_dates) || [],
+    fundingRules: parseJsonArray(grant.eligible_cost_categories) || [],
+    generalInfo: parseJsonArray(grant.other_templates_names) || [],
+    requirements: [
+      ...(parseJsonArray(grant.eligible_cost_categories) || []),
+      ...(parseJsonArray(grant.eligible_organisations) || []),
+      ...(parseJsonArray(grant.industry_sectors) || [])
+    ].filter(Boolean),
+    contact: {
+      name: grant.contact_name || '',
+      organization: grant.contact_title || '',
+      email: grant.contact_email || '',
+      phone: grant.contact_phone || ''
+    },
+    templates: parseJsonArray(grant.application_templates_names) || [],
+    application_templates_links: parseJsonArray(grant.application_templates_links),
+    other_templates_links: parseJsonArray(grant.other_templates_links),
+    other_sources_links: parseJsonArray(grant.other_sources_links),
+    other_sources_names: parseJsonArray(grant.other_sources_names),
+    evaluationCriteria: grant.evaluation_criteria || '',
+    applicationProcess: grant.application_process || '',
+    originalUrl: grant.original_url || '',
+    consortium_requirement: (typeof grant.consortium_requirement === 'string' ? grant.consortium_requirement.trim() : grant.consortium_requirement) || undefined,
+    cofinancing_required: parseBooleanString(grant.cofinancing_required),
+    cofinancing_level: grant.cofinancing_level ?? null,
+    application_opening_date: grant.application_opening_date,
+    application_closing_date: grant.application_closing_date,
+    project_start_date_min: grant.project_start_date_min,
+    project_start_date_max: grant.project_start_date_max,
+    project_end_date_min: grant.project_end_date_min,
+    project_end_date_max: grant.project_end_date_max,
+    information_webinar_dates: parseJsonArray(grant.information_webinar_dates),
+    information_webinar_links: parseJsonArray(grant.information_webinar_links),
+    information_webinar_names: parseJsonArray(grant.information_webinar_names),
+    other_important_dates: parseJsonArray(grant.other_important_dates),
+    other_important_dates_labels: parseJsonArray(grant.other_important_dates_labels)
+  };
+
+  return grantDetails;
 };
 
 const formatFundingAmount = (min?: number, max?: number, total?: number): string => {

--- a/src/types/grant.ts
+++ b/src/types/grant.ts
@@ -30,6 +30,7 @@ export interface Grant {
   eligible_organisations?: string[];
   consortium_requirement?: boolean;
   geographic_scope?: string[];
+  region?: string;
   cofinancing_required?: boolean;
   cofinancing_level_min?: number;
   cofinancing_level_max?: number;
@@ -45,6 +46,8 @@ export interface Grant {
   information_webinar_dates?: string[];
   information_webinar_links?: string[];
   information_webinar_names?: string[];
+  other_important_dates?: string[];
+  other_important_dates_labels?: string[];
 }
 
 // Minimal data for grant list items
@@ -71,6 +74,8 @@ export interface GrantListItem {
   information_webinar_dates?: string[];
   information_webinar_links?: string[];
   information_webinar_names?: string[];
+  other_important_dates?: string[];
+  other_important_dates_labels?: string[];
   // Template fields for files and documents
   templates?: string[];
   generalInfo?: string[];
@@ -122,4 +127,6 @@ export interface GrantDetails extends GrantListItem {
   information_webinar_dates?: string[];
   information_webinar_links?: string[];
   information_webinar_names?: string[];
+  other_important_dates?: string[];
+  other_important_dates_labels?: string[];
 }

--- a/src/utils/grantTransform.ts
+++ b/src/utils/grantTransform.ts
@@ -24,6 +24,8 @@ type PartialSupabaseGrantRow = Pick<
   | 'information_webinar_dates'
   | 'information_webinar_links'
   | 'information_webinar_names'
+  | 'other_important_dates'
+  | 'other_important_dates_labels'
   | 'application_templates_names'
   | 'other_templates_names'
   | 'evaluation_criteria'
@@ -215,6 +217,7 @@ export const transformSupabaseGrant = (supabaseGrant: PartialSupabaseGrantRow): 
         ...normalizeGeographicValues((supabaseGrant as any).geographic_scope),
         ...normalizeGeographicValues(supabaseGrant.region)
       ].filter((item, index, arr) => arr.indexOf(item) === index), // Remove duplicates
+      region: supabaseGrant.region || undefined,
       cofinancing_required: supabaseGrant.cofinancing_required || false,
       cofinancing_level_min: supabaseGrant.cofinancing_level_min || undefined,
       cofinancing_level_max: supabaseGrant.cofinancing_level_max || undefined,
@@ -230,6 +233,8 @@ export const transformSupabaseGrant = (supabaseGrant: PartialSupabaseGrantRow): 
       information_webinar_dates: jsonToStringArray(supabaseGrant.information_webinar_dates),
       information_webinar_links: jsonToStringArray(supabaseGrant.information_webinar_links),
       information_webinar_names: jsonToStringArray(supabaseGrant.information_webinar_names),
+      other_important_dates: jsonToStringArray(supabaseGrant.other_important_dates),
+      other_important_dates_labels: jsonToStringArray(supabaseGrant.other_important_dates_labels),
     };
 
     console.log('✅ Transformation successful for:', transformed.id, transformed.title);
@@ -242,7 +247,9 @@ export const transformSupabaseGrant = (supabaseGrant: PartialSupabaseGrantRow): 
       project_end_date_max: transformed.project_end_date_max,
       information_webinar_dates: transformed.information_webinar_dates,
       information_webinar_names: transformed.information_webinar_names,
-      information_webinar_links: transformed.information_webinar_links
+      information_webinar_links: transformed.information_webinar_links,
+      other_important_dates: transformed.other_important_dates,
+      other_important_dates_labels: transformed.other_important_dates_labels
     });
     return transformed;
   } catch (error) {


### PR DESCRIPTION
- Updated components to replace the `Grant` type with `GrantDetails` for better type specificity.
- Adjusted the `GrantNotionDescriptionSection` to use `description` instead of `long_description`.
- Enhanced the `GrantNotionImportantDatesSection` to handle additional important date fields.

Files modified include: `GrantDetails.tsx`, `GrantNotionAdditionalInfoSection.tsx`, `GrantNotionApplicationSection.tsx`, `GrantNotionContactSection.tsx`, `GrantNotionContent.tsx`, `GrantNotionDescriptionSection.tsx`, `GrantNotionEvaluationSection.tsx`, `GrantNotionFundingRulesSection.tsx`, `GrantNotionHeader.tsx`, `GrantNotionImportantDatesSection.tsx`, `GrantNotionKeyInfo.tsx`, `GrantNotionQualificationsSection.tsx`, `GrantNotionTemplatesSection.tsx`, `types.ts`, `grantsService.ts`, and `grantTransform.ts`.