### PR TITLE
Fix sorting for "Nyast publicerat" to use updated_at timestamps

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -106,6 +106,34 @@
 
 **Status**: ✅ Completed
 
+### Sorting Fix for "Nyast publicerat" - 2024-12-19
+**Description**: Fixed the sorting function for "Nyast publicerat" (newest published) to use the correct `updated_at` field instead of incorrect data points.
+
+**Problem Identified**:
+- The "Nyast publicerat" sorting option was not accurately determining the newest published grants
+- **Backend**: Was using `created_at` instead of `updated_at` for sorting
+- **Frontend**: Was using `b.id.localeCompare(a.id)` as a proxy for creation date, which is completely wrong
+- **Database Queries**: Missing `updated_at` field in SELECT statements
+
+**Changes Made**:
+- **Backend Function**: Updated `filtered-grants-search` to use `updated_at` instead of `created_at` for `created-desc` sorting
+- **Database Queries**: Added `updated_at` field to SELECT statements in both frontend and backend
+- **Frontend Sorting**: Fixed `grantSorting.ts` to use actual `updated_at` timestamps instead of ID comparison
+- **Type Definitions**: Added `created_at` and `updated_at` fields to `GrantListItem` interface
+- **Data Transformation**: Updated all transformation functions to include timestamp fields
+
+**Technical Details**:
+- Updated `supabase/functions/filtered-grants-search/index.ts` - Changed sorting logic and added `updated_at` to SELECT
+- Updated `src/services/grantsService.ts` - Added `updated_at` to SELECT and transformation
+- Updated `src/hooks/useBackendFilteredGrants.ts` - Added `updated_at` to transformation
+- Updated `src/types/grant.ts` - Added timestamp fields to GrantListItem interface
+- Updated `src/utils/grantSorting.ts` - Fixed frontend sorting to use actual timestamps
+
+**Result**:
+Now when users select "Nyast publicerat" (newest published), the grants will be sorted by their actual `updated_at` timestamp, showing the most recently updated/published grants first.
+
+**Status**: ✅ Completed
+
 ### Date Handling and Display Improvements - 2024-12-19
 **Description**: Fixed date handling issues and improved the display of important dates in grant details.
 

--- a/src/hooks/useBackendFilteredGrants.ts
+++ b/src/hooks/useBackendFilteredGrants.ts
@@ -127,7 +127,10 @@ const transformSupabaseGrantToListItem = (grant: any): GrantListItem => {
     cofinancing_level: grant.cofinancing_level ?? null,
     consortium_requirement: (typeof grant.consortium_requirement === 'string' ? grant.consortium_requirement.trim() : grant.consortium_requirement) || undefined,
     region: grant.region || null,
-    fundingRules: parseJsonArray(grant.eligible_cost_categories) || []
+    fundingRules: parseJsonArray(grant.eligible_cost_categories) || [],
+    // Timestamp fields
+    created_at: grant.created_at,
+    updated_at: grant.updated_at
   };
 };
 

--- a/src/services/grantsService.ts
+++ b/src/services/grantsService.ts
@@ -67,7 +67,8 @@ export const fetchGrantListItems = async (): Promise<GrantListItem[]> => {
       project_end_date_min, project_end_date_max, information_webinar_dates, information_webinar_links,
       information_webinar_names, application_templates_names, application_templates_links, other_templates_names,
       other_templates_links, other_sources_names, other_sources_links, keywords, industry_sectors, eligible_organisations, 
-      geographic_scope, cofinancing_required, cofinancing_level, consortium_requirement, region, eligible_cost_categories
+      geographic_scope, cofinancing_required, cofinancing_level, consortium_requirement, region, eligible_cost_categories,
+      created_at, updated_at
     `)
     .order('created_at', { ascending: false });
 
@@ -202,7 +203,10 @@ const transformGrantListItems = (grantData: any[]): GrantListItem[] => {
         cofinancing_level: grant.cofinancing_level ?? null,
         consortium_requirement: (typeof grant.consortium_requirement === 'string' ? grant.consortium_requirement.trim() : grant.consortium_requirement) || undefined,
         region: grant.region || '',
-        fundingRules: parseJsonArray(grant.eligible_cost_categories) || []
+        fundingRules: parseJsonArray(grant.eligible_cost_categories) || [],
+        // Timestamp fields
+        created_at: grant.created_at,
+        updated_at: grant.updated_at
       };
       
       transformedItems.push(transformed);

--- a/src/types/grant.ts
+++ b/src/types/grant.ts
@@ -88,6 +88,9 @@ export interface GrantListItem {
   cofinancing_level?: number;
   consortium_requirement?: string | boolean;
   fundingRules?: string[];
+  // Timestamp fields
+  created_at?: string;
+  updated_at?: string;
 }
 
 // Full data for grant details (extends GrantListItem)

--- a/src/utils/grantSorting.ts
+++ b/src/utils/grantSorting.ts
@@ -122,9 +122,10 @@ export const sortGrants = (grants: GrantListItem[], sortBy: SortOption, searchTe
         return amountA2 - amountB2; // Lowest funding first
       
       case "created-desc":
-        // For now, sort by grant ID as a proxy for creation date
-        // In a real app, you'd have a proper created_at field
-        return b.id.localeCompare(a.id);
+        // Sort by updated_at field for "Nyast publicerat" (newest published)
+        const updatedA = a.updated_at ? new Date(a.updated_at).getTime() : 0;
+        const updatedB = b.updated_at ? new Date(b.updated_at).getTime() : 0;
+        return updatedB - updatedA; // Most recently updated first
       
       case "relevance":
       case "matching":

--- a/supabase/functions/filtered-grants-search/index.ts
+++ b/supabase/functions/filtered-grants-search/index.ts
@@ -73,7 +73,7 @@ serve(async (req) => {
         project_end_date_min, project_end_date_max, information_webinar_dates, information_webinar_links,
         information_webinar_names, application_templates_names, application_templates_links, other_templates_names,
         other_templates_links, other_sources_names, other_sources_links, keywords, industry_sectors, eligible_organisations, 
-        geographic_scope, cofinancing_required, cofinancing_level_min, created_at
+        geographic_scope, cofinancing_required, cofinancing_level_min, created_at, updated_at
       `, { count: 'exact' });
 
     // Filter out grants with passed deadlines
@@ -168,11 +168,11 @@ serve(async (req) => {
         query = query.order('max_funding_per_project', { ascending: true, nullsLast: true });
         break;
       case 'created-desc':
-        query = query.order('created_at', { ascending: false });
+        query = query.order('updated_at', { ascending: false });
         break;
       default:
-        // Default sorting by created_at descending
-        query = query.order('created_at', { ascending: false });
+        // Default sorting by updated_at descending
+        query = query.order('updated_at', { ascending: false });
         break;
     }
 


### PR DESCRIPTION
- Updated backend and frontend sorting logic to correctly sort grants by the updated_at field instead of created_at or ID comparison.
- Added updated_at and created_at fields to GrantListItem interface and relevant database queries.
- Ensured all transformation functions include timestamp fields for accurate data handling.

Now, selecting "Nyast publicerat" will display grants sorted by their most recent updates.