### PR TITLE
Refactor funding amount handling and disable debug logging

### DIFF
--- a/src/hooks/useBackendFilteredGrants.ts
+++ b/src/hooks/useBackendFilteredGrants.ts
@@ -4,7 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { GrantListItem } from '@/types/grant';
 import { EnhancedFilterOptions } from '@/hooks/useFilterState';
 import { SortOption } from '@/components/SortingControls';
-import { formatFundingAmount } from '@/utils/grantHelpers';
+
 
 interface BackendFilterOptions {
   organizations?: string[];

--- a/src/services/grantsService.ts
+++ b/src/services/grantsService.ts
@@ -333,7 +333,7 @@ const transformGrantListItems = (grantData: any[]): GrantListItem[] => {
         title: title || 'Untitled Grant',
         organization: grant.organisation || 'Unknown Organization',
         aboutGrant: subtitle || 'No information available',
-        fundingAmount: formatFundingAmount(grant),
+        fundingAmount: grant.funding_amount_eur ? `${grant.funding_amount_eur.toLocaleString()} EUR` : 'Not specified',
         funding_amount_eur: grant.funding_amount_eur || null,
         opens_at: grant.application_opening_date || '2024-01-01',
         deadline: grant.application_closing_date || 'Not specified',

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -47,5 +47,6 @@ export const debugGrant = (operation: string, data: any) => {
  * @param result - The formatted result
  */
 export const debugFundingAmount = (type: string, result: string) => {
-  debugLog(`formatFundingAmount: ${type} -> ${result}`);
+  // Disabled debug logging for funding amount formatting to reduce console noise
+  // debugLog(`formatFundingAmount: ${type} -> ${result}`);
 }; 


### PR DESCRIPTION
- Updated the `transformGrantListItems` function to directly format the funding amount using the `funding_amount_eur` field, improving clarity and consistency.
- Removed the `formatFundingAmount` utility function from imports and adjusted the logic to handle undefined values more gracefully.
- Disabled debug logging for funding amount formatting to reduce console noise, enhancing overall performance and readability in the debug output.